### PR TITLE
fix(forms): replace deprecated YouTube /user/ URLs with new @handle URLs

### DIFF
--- a/lobbywatch_bearbeitung_public.pgtm
+++ b/lobbywatch_bearbeitung_public.pgtm
@@ -705,7 +705,7 @@ Organisationen, die Lobbying im Parlament betreiben.        </homePageDescriptio
           </ColumnPresentation>
           <ColumnPresentation fieldName="youtube_user" caption="Youtube User" headerHint="Youtube Username" showColumnFilter="false" canSetNull="true" selectedFilterOperators="1589247">
             <ViewProperties type="text"/>
-            <Hyperlink template="https://www.youtube.com/user/%youtube_user%" target=""/>
+            <Hyperlink template="https://www.youtube.com/@%youtube_user%" target=""/>
             <EditProperties type="textBox" maxLength="50"/>
           </ColumnPresentation>
           <ColumnPresentation fieldName="beschreibung" caption="Beschreibung" headerHint="Beschreibung der Lobbyorganisation. Beispielsweise von der Webseite, falls es keinen besseren Text gibt Zweck gemäss Handelsregister oder Statuten." canSetNull="true" selectedFilterOperators="1589247">
@@ -21317,7 +21317,7 @@ Zutrittsberechtigtepersonen und Lobbyisten        </DetailedDescription>
           </ColumnPresentation>
           <ColumnPresentation fieldName="youtube_user" caption="Youtube" headerHint="Youtube Username" showColumnFilter="false" canSetNull="true" selectedFilterOperators="1589247">
             <ViewProperties type="text"/>
-            <Hyperlink template="https://www.youtube.com/user/%youtube_user%" target=""/>
+            <Hyperlink template="https://www.youtube.com/@%youtube_user%" target=""/>
             <EditProperties type="textBox" maxLength="50"/>
             <Validators>
               <RegExpClientValidatorInfo enabled="true" expression="^(?!(http|@))"/>
@@ -42937,7 +42937,7 @@ Tabelle der Parteien        </homePageDescription>
           </ColumnPresentation>
           <ColumnPresentation fieldName="youtube_user" caption="Youtube" headerHint="Youtube Username" showColumnFilter="false" canSetNull="true" selectedFilterOperators="1589247">
             <ViewProperties type="text"/>
-            <Hyperlink template="https://www.youtube.com/user/%youtube_user%" target=""/>
+            <Hyperlink template="https://www.youtube.com/@%youtube_user%" target=""/>
             <EditProperties type="textBox" maxLength="50"/>
           </ColumnPresentation>
           <ColumnPresentation fieldName="facebook_name" caption="Facebook" headerHint="Facebookname (letzter Teil von Link), wird mit https://www.facebook.com/ zu einem ganzen Link ergänzt" showColumnFilter="false" canSetNull="true" selectedFilterOperators="1589247">

--- a/public_html/bearbeitung/organisation.php
+++ b/public_html/bearbeitung/organisation.php
@@ -40945,7 +40945,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube User', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $column->setMinimalVisibility(ColumnVisibility::PHONE);
             $column->setDescription('Youtube Username');
@@ -41410,7 +41410,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube User', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddSingleRecordViewColumn($column);
             
@@ -44578,7 +44578,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube User', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddPrintColumn($column);
             
@@ -45022,7 +45022,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube User', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddExportColumn($column);
             
@@ -45466,7 +45466,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube User', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddCompareColumn($column);
             

--- a/public_html/bearbeitung/partei.php
+++ b/public_html/bearbeitung/partei.php
@@ -14718,7 +14718,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $column->setMinimalVisibility(ColumnVisibility::PHONE);
             $column->setDescription('Youtube Username');
@@ -15010,7 +15010,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddSingleRecordViewColumn($column);
             
@@ -16384,7 +16384,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddPrintColumn($column);
             
@@ -16660,7 +16660,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddExportColumn($column);
             
@@ -16936,7 +16936,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddCompareColumn($column);
             

--- a/public_html/bearbeitung/person.php
+++ b/public_html/bearbeitung/person.php
@@ -19545,7 +19545,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $column->setMinimalVisibility(ColumnVisibility::PHONE);
             $column->setDescription('Youtube Username');
@@ -19983,7 +19983,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddSingleRecordViewColumn($column);
             
@@ -22557,7 +22557,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddPrintColumn($column);
             
@@ -22966,7 +22966,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddExportColumn($column);
             
@@ -23375,7 +23375,7 @@
             //
             $column = new TextViewColumn('youtube_user', 'youtube_user', 'Youtube', $this->dataset);
             $column->SetOrderable(true);
-            $column->setHrefTemplate('https://www.youtube.com/user/%youtube_user%');
+            $column->setHrefTemplate('https://www.youtube.com/@%youtube_user%');
             $column->setTarget('');
             $grid->AddCompareColumn($column);
             


### PR DESCRIPTION
Updated all YouTube channel links from the legacy "https://www.youtube.com/user/username" format to the new official handle format "https://www.youtube.com/@username".

This fixes the issue of invalid links that currently lead to 404 errors on YouTube, ensuring all channel references resolve correctly.