### PR TITLE
fix(db): allow longer abbreviations for committees

### DIFF
--- a/db_changes.sql
+++ b/db_changes.sql
@@ -4500,3 +4500,9 @@ ALTER TABLE `translation_source`
 
 ALTER TABLE `translation_source_log`
   CHANGE `version` `version` VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT 'Version of Lobbywatch, where the string was last updated (for translation optimization).';
+
+-- 29.5.2026 Allow longer abbreviations for committees
+
+ALTER TABLE `kommission` CHANGE `abkuerzung` `abkuerzung` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Kürzel der Kommission';
+ALTER TABLE `kommission` CHANGE `abkuerzung_fr` `abkuerzung_fr` VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT 'Französisches Kürzel der Kommission';
+

--- a/lobbywatch.sql
+++ b/lobbywatch.sql
@@ -2450,8 +2450,8 @@ SET @saved_cs_client     = @@character_set_client ;
 SET character_set_client = utf8 ;
 CREATE TABLE `kommission` (
   `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Technischer Schlüssel der Kommission',
-  `abkuerzung` varchar(15) NOT NULL COMMENT 'Kürzel der Kommission',
-  `abkuerzung_fr` varchar(15) DEFAULT NULL COMMENT 'Französisches Kürzel der Kommission',
+  `abkuerzung` varchar(64) NOT NULL COMMENT 'Kürzel der Kommission',
+  `abkuerzung_fr` varchar(64) DEFAULT NULL COMMENT 'Französisches Kürzel der Kommission',
   `name` varchar(100) NOT NULL COMMENT 'Ausgeschriebener Name der Kommission',
   `name_fr` varchar(120) DEFAULT NULL COMMENT 'Ausgeschriebener französischer Name der Kommission',
   `rat_id` int(11) DEFAULT NULL COMMENT 'Ratszugehörigkeit; Fremdschlüssel des Rates',


### PR DESCRIPTION
@grossbart warum passen wir es an beiden Stellen an? 

Aus meiner Sicht könnte lobbywatch.sql die baseline sein und in db_changes.sql schreiben wir nur die Anpassungen rein.

Die Anpassungen habe ich bereits per phpmyadmin eingespielt.